### PR TITLE
Add playlists for vis event fast forwards (ful/short/cga papers, posters) on the event pages

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,6 @@ by_uid = {}
 by_day = {}
 by_time = {}
 
-
 def main(site_data_path):
     global site_data, extra_files
     extra_files = ["README.md"]
@@ -485,6 +484,9 @@ def poster_session():
     data["requires_auth"] = True
     data["session"] = format_by_session_list(v)
     data["event"] = format_session_as_event(by_uid['events'][uid], uid)
+    if uid in site_data["event_ff_playlists"]:
+        data["event"]["ff_playlist"] = site_data["event_ff_playlists"][uid]
+        data["event"]["ff_playlist_id"] = site_data["event_ff_playlists"][uid].split("=")[-1]
     return render_template("poster_session.html", **data)
 
 
@@ -504,6 +506,9 @@ def event(event):
     v = by_uid['events'][uid]
     data = _data()
     data["event"] = format_session_as_event(v, uid)
+    if uid in site_data["event_ff_playlists"]:
+        data["event"]["ff_playlist"] = site_data["event_ff_playlists"][uid]
+        data["event"]["ff_playlist_id"] = site_data["event_ff_playlists"][uid].split("=")[-1]
     return render_template("event.html", **data)
 
 

--- a/sitedata/event_ff_playlists.json
+++ b/sitedata/event_ff_playlists.json
@@ -1,0 +1,7 @@
+{
+    "cga-papers": "https://www.youtube.com/playlist?list=PLjHCTOW5ojrfzyMVDOpzTErUs6zdKcoMq",
+    "f-papers": "https://www.youtube.com/playlist?list=PLjHCTOW5ojrcpk3HYLWKixAYydFF8N_pa",
+    "s-papers": "https://www.youtube.com/playlist?list=PLjHCTOW5ojremiVhP-TN_ScBXGUvsqcqY",
+    "x-posters": "https://www.youtube.com/playlist?list=PLjHCTOW5ojreEQ_3tMemcLnoR1_MxJIBl"
+}
+

--- a/templates/event.html
+++ b/templates/event.html
@@ -32,6 +32,13 @@
             <a href="https://ieeevis.b-cdn.net/vis_2020/ics/{{ event.id }}.ics">
             Add all of this event's sessions to your calendar</a>.
         </h5>
+        {% if event.ff_playlist %}
+        <h5 class="session-info my-4">
+            <a href="#ff">
+                Jump to Fast Forwards
+                <span class="fas mr-2">&#xf87c;</span></a>
+        </h5>
+        {% endif %}
     </div>
 </div>
 
@@ -48,5 +55,16 @@
 
 {{ components.session_listing(event.sessions, config["calendar"]["colors"], True, True) }}
 
+
+{% if event.ff_playlist %}
+<hr>
+<div class="row my-4">
+    <div class="col-lg-10">
+        <h2 class="my-3"><a name="ff">Fast forwards in this event's sessions</a></h2>
+        <iframe width="920" height="518" src="https://www.youtube-nocookie.com/embed/videoseries?list={{ event.ff_playlist_id }}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <p class="integration-description pt-2">Direct link to YouTube playlist: <a href="{{ event.ff_playlist }}" target="_blank">{{ event.ff_playlist }}</a></p>
+    </div>
+</div>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This adds the full/short/cga and poster playlists to their event pages since folks also asked for whole event FF playlists instead of just per-session. If an event has a FF playlist there will be a "jump" link at the top, similar to what's on the session pages. (this is basically just copy-paste from the session page template)